### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Those tools were presented during "**Groovy DevOps in the Cloud**" talk at **Jav
 
 This setup provides a **Gradle** script (`build.gradle`) that glues together all bits and pieces:
 
-- `createInstance` task starts new machine in EC2 
+- `startInstance` task starts new machine in EC2 
 - `uploadModules` task uploads Puppet modules to the newly created machine
 - `test` task runs JUnit integration tests against the newly created machine
 - `terminateInstance` task terminates the machine

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Groovy DevOps in the Cloud
 
 This project provides an example setup that shows features of Sshoogr (<https://github.com/aestasit/sshoogr>), Gramazon (<https://github.com/aestasit/gramazon>) and PuppetUnit (<https://github.com/aestasit/puppet-unit>). 
@@ -18,8 +17,8 @@ Before you can take advantage of this setup, you will need to at least:
 - Create **AWS** account
 - Create **access and secret keys** to call EC2 API
 - Set access and secret keys inside `gradle.properties`
-- Create new key pair called `cloud-do` (or change the name of the key in the `build.gradle` file to match any of the existing keys)
-- Save newly generated private key in the root directory of the project as `cloud-do.pem` (or change `build.gradle` to match your file name)
+- Create new key pair called `cloud-do` in `eu-west-1` region (or change the name of the key or the region in the `build.gradle` file to match any of the existing keys)
+- Save newly generated private key in the root directory of the project as `cloud-do.pem` (or change `build.gradle` to match your file name or region)
 - Create new security group `cloud-do` (or change the name of the security group in the `build.gradle` file to match any of the existing security groups)
 - Allow inbound connecitons on port `22` for the configured security group
 - Change the AMI identifier inside the `build.gradle` to match your OS image which has Puppet already installed


### PR DESCRIPTION
Security groups and keypairs should be created in `eu-west-1` region (or configuration should be altered)

Made this explicit in instructions
